### PR TITLE
fix(security): CSP unsafe-eval for Turnstile, non-passive touch listeners

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -14,7 +14,7 @@ export async function handle({ event, resolve }) {
         'Content-Security-Policy',
         [
             "default-src 'self'",
-            "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://static.cloudflareinsights.com",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://static.cloudflareinsights.com",
             "style-src 'self' 'unsafe-inline'",
             "img-src 'self' data: https://adamantium.online",
             "font-src 'self'",

--- a/src/lib/component/game-wrapper.svelte
+++ b/src/lib/component/game-wrapper.svelte
@@ -286,6 +286,11 @@
 			if (saved) game.highScore = parseInt(saved, 10) || 0;
 		} catch {}
 
+		// Touch events must be non-passive to allow preventDefault()
+		canvas.addEventListener('touchstart', onTouchStart, { passive: false });
+		canvas.addEventListener('touchmove', onTouchMove, { passive: false });
+		canvas.addEventListener('touchend', onTouchEnd, { passive: false });
+
 		document.addEventListener('fullscreenchange', onFullscreenChange);
 		gameLoop(performance.now());
 
@@ -310,6 +315,9 @@
 		}).catch(() => {});
 
 		return () => {
+			canvas.removeEventListener('touchstart', onTouchStart);
+			canvas.removeEventListener('touchmove', onTouchMove);
+			canvas.removeEventListener('touchend', onTouchEnd);
 			if (animFrameId) cancelAnimationFrame(animFrameId);
 			document.removeEventListener('fullscreenchange', onFullscreenChange);
 			document.body.style.overflow = '';
@@ -349,9 +357,6 @@
 		width={CANVAS_W}
 		height={CANVAS_H}
 		onclick={onCanvasClick}
-		ontouchstart={onTouchStart}
-		ontouchmove={onTouchMove}
-		ontouchend={onTouchEnd}
 	></canvas>
 
 	<!-- Turnstile (hidden widget, renders above canvas) -->


### PR DESCRIPTION
## Summary
- Add `unsafe-eval` to CSP `script-src` — required by Cloudflare Turnstile's challenge iframe for internal bot detection (error 600010)
- Switch canvas touch events from Svelte declarative handlers (`ontouchstart`) to imperative `addEventListener` with `{ passive: false }` — fixes "Unable to preventDefault inside passive event listener" warnings

## Test plan
- [ ] Turnstile widget loads without CSP errors on /game
- [ ] Touch input works on mobile without console warnings
- [ ] No regressions on desktop keyboard/mouse input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced touch event handling for improved responsiveness and smoother interactions on touch-enabled devices.

* **Security**
  * Updated security policy configuration to support script execution requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->