### PR TITLE
fix(game): bottom nav on game page, wallet icon aspect ratio

### DIFF
--- a/src/lib/game/hud.js
+++ b/src/lib/game/hud.js
@@ -411,10 +411,15 @@ export function drawTitleScreen(ctx, now, playerName, walletState) {
 				ctx.roundRect(cellX + 4, cellY, cellW - 8, cellH, 8);
 				ctx.stroke();
 
-				// Icon
+				// Icon (preserve aspect ratio)
 				const icon = getWalletIcon(w.icon);
 				if (icon.loaded) {
-					ctx.drawImage(icon.img, cellCx - iconSize / 2, cellY + 8, iconSize, iconSize);
+					const nw = icon.img.naturalWidth || iconSize;
+					const nh = icon.img.naturalHeight || iconSize;
+					const scale = Math.min(iconSize / nw, iconSize / nh);
+					const dw = nw * scale;
+					const dh = nh * scale;
+					ctx.drawImage(icon.img, cellCx - dw / 2, cellY + 8 + (iconSize - dh) / 2, dw, dh);
 				} else {
 					ctx.fillStyle = COLOR.textDim;
 					ctx.fillRect(cellCx - iconSize / 2, cellY + 8, iconSize, iconSize);
@@ -719,7 +724,7 @@ export function drawTitleScreen(ctx, now, playerName, walletState) {
 		ctx.font = '11px monospace';
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
-		ctx.fillText('NO SCORES YET', cx, lbBoxY + 26);
+		ctx.fillText('NO SCORES YET', cx, lbBoxY + 30);
 	}
 
 	// Scanlines

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,7 +81,6 @@
 </nav>
 
 <!-- Mobile Scanner Drawer — slides up from bottom nav -->
-{#if page.url.pathname !== '/game'}
 {#if scanDrawerOpen}
 	<!-- Backdrop -->
 	<button
@@ -166,7 +165,6 @@
 		</button>
 	</div>
 </nav>
-{/if}
 
 <!-- Main content area — offset for desktop side rail -->
 <main class="lg:ml-44 pb-20 lg:pb-0">


### PR DESCRIPTION
## Summary
- Show bottom nav on `/game` route (was hidden, leaving no mobile navigation)
- Preserve wallet icon aspect ratio in canvas title screen (fixes Eternl icon distortion)
- Nudge "NO SCORES YET" text down slightly on mobile

## Test plan
- [ ] Game page shows bottom nav on mobile
- [ ] Bridge back button still visible
- [ ] Eternl icon renders without distortion on title screen
- [ ] Other wallet icons unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed wallet icon display to preserve aspect ratio on title screen
* Adjusted vertical spacing of the leaderboard "No Scores Yet" label

## Changes
* Mobile scanner drawer is now accessible on the game screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->